### PR TITLE
Fix set of public Handshake interface to remove circular reference.

### DIFF
--- a/PInvokeSerialPort/SerialPort.cs
+++ b/PInvokeSerialPort/SerialPort.cs
@@ -709,8 +709,8 @@ namespace PInvokeSerialPort
             get { return _handShake; }
             set
             {
-                Handshake = value;
-                switch (Handshake)
+                _handShake = value;
+                switch (_handShake)
                 {
                     case Handshake.None:
                         TxFlowCts = false; TxFlowDsr = false; TxFlowX = false;


### PR DESCRIPTION
I needed to make this change so I could set handshake.