### PR TITLE
set _rxThread to Background thread, making sure it will exit when the…

### DIFF
--- a/PInvokeSerialPort/SerialPort.cs
+++ b/PInvokeSerialPort/SerialPort.cs
@@ -109,6 +109,8 @@ namespace PInvokeSerialPort
                                 Name = "CommBaseRx",
                                 Priority = ThreadPriority.AboveNormal
                             };
+            //If not set to true, my application process will not exit completely after UI closed
+            _rxThread.IsBackground = true;
             _rxThread.Start();
             Thread.Sleep(1); //Give rx thread time to start. By documentation, 0 should work, but it does not!
 

--- a/PInvokeSerialPort/SerialPort.cs
+++ b/PInvokeSerialPort/SerialPort.cs
@@ -711,8 +711,8 @@ namespace PInvokeSerialPort
             get { return _handShake; }
             set
             {
-                Handshake = value;
-                switch (Handshake)
+                _handShake = value;
+                switch (_handShake)
                 {
                     case Handshake.None:
                         TxFlowCts = false; TxFlowDsr = false; TxFlowX = false;


### PR DESCRIPTION
… main(UI) thread exits.
I encountered this issue when I used this library today, and wasted a lot of time debugging, finally found the background process in TaskBar after the UI closed.